### PR TITLE
Add a type-specific Spliterator that wraps iterators

### DIFF
--- a/TODO
+++ b/TODO
@@ -19,8 +19,6 @@
 - Fix comparator() in SortedSet not being specified in the same way as in SortedMap
 - Document the return value of map generic methods (null? default return value?).
 - Spliterator implementations for RBTreeSet/Map, AVLTreeSet/Map, and ArrayFrontCodedLists
-- Find a cleaner way to handle "intSpliterator wraps shortSpliterator only if safe" idea
-  Aka, find a way to get rid of Collection.ImplementsSpliterator
   If we can accept breaking backwards compatibilty, an easy way to fix this is to just make spliterator() abstract
   A less easy way is to reimplement Spliterators.spliterator(XIterator) (aka, add type-specific Spliterator views of Iterators)
 - Implement type-specific Iterator views of Spliterator (aka, Spliterators.iterator(Spliterator))

--- a/drv/AbstractBigList.drv
+++ b/drv/AbstractBigList.drv
@@ -182,7 +182,7 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 #if KEY_WIDENED
 	@Override
 	public WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR KEY_GENERIC KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof COLLECTION.ImplementsSpliterator || this instanceof java.util.RandomAccess) {
+		if (this instanceof java.util.RandomAccess) {
 			return SPLITERATORS.widen(spliterator());
 		} else {
 			return super.KEY_WIDENED_SPLITERATOR_METHOD();
@@ -812,7 +812,7 @@ public abstract class ABSTRACT_BIG_LIST KEY_GENERIC extends ABSTRACT_COLLECTION 
 #if KEYS_WIDENED
 		@Override
 		public WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR KEY_GENERIC KEY_WIDENED_SPLITERATOR_METHOD() {
-			if (l instanceof java.util.RandomAccess || this instanceof COLLECTION.ImplementsSpliterator) {
+			if (l instanceof java.util.RandomAccess) {
 				return SPLITERATORS.widen(spliterator());
 			} else {
 				return super.KEY_WIDENED_SPLITERATOR_METHOD();

--- a/drv/AbstractList.drv
+++ b/drv/AbstractList.drv
@@ -184,17 +184,6 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		}
 	}
 
-#if KEY_WIDENED
-	@Override
-	public WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR KEY_GENERIC KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof COLLECTION.ImplementsSpliterator || this instanceof java.util.RandomAccess) {
-			return SPLITERATORS.widen(spliterator());
-		} else {
-			return LIST.super.KEY_WIDENED_SPLITERATOR_METHOD();
-		}
-	}
-#endif
-
 	/** Returns true if this list contains the specified element.
 	 * <p>This implementation delegates to {@code indexOf()}.
 	 * @see List#contains(Object)
@@ -776,17 +765,6 @@ public abstract class ABSTRACT_LIST KEY_GENERIC extends ABSTRACT_COLLECTION KEY_
 		public KEY_SPLITERATOR KEY_GENERIC spliterator() {
 			return l instanceof java.util.RandomAccess ? new IndexBasedSpliterator KEY_GENERIC_DIAMOND(l, from, to) : super.spliterator();
 		}
-
-#if KEYS_WIDENED
-		@Override
-		public WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR KEY_GENERIC KEY_WIDENED_SPLITERATOR_METHOD() {
-			if (l instanceof java.util.RandomAccess || this instanceof COLLECTION.ImplementsSpliterator) {
-				return SPLITERATORS.widen(spliterator());
-			} else {
-				return super.KEY_WIDENED_SPLITERATOR_METHOD();
-			}
-		}
-#endif
 
 		@Override
 		public LIST KEY_GENERIC subList(final int from, final int to) {

--- a/drv/ArrayList.drv
+++ b/drv/ArrayList.drv
@@ -53,7 +53,7 @@ import java.util.Comparator;
  * @see java.util.ArrayList
  */
 
-public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements LIST.ImplementsSpliterator KEY_GENERIC, RandomAccess, Cloneable, java.io.Serializable {
+public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements RandomAccess, Cloneable, java.io.Serializable {
 	private static final long serialVersionUID = -7046029254386353130L;
 
 
@@ -517,7 +517,7 @@ public class ARRAY_LIST KEY_GENERIC extends ABSTRACT_LIST KEY_GENERIC implements
 		assert size <= a.length;
 	}
 
-	private class SubList extends ABSTRACT_LIST.SUBLIST_RANDOM_ACCESS KEY_GENERIC implements LIST.ImplementsSpliterator KEY_GENERIC {
+	private class SubList extends ABSTRACT_LIST.SUBLIST_RANDOM_ACCESS KEY_GENERIC {
 		private static final long serialVersionUID = -3185226345314976296L;
 
 		protected SubList(int from, int to) {

--- a/drv/ArrayMap.drv
+++ b/drv/ArrayMap.drv
@@ -123,7 +123,7 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 		if (size > key.length) throw new IllegalArgumentException("The provided size (" + size + ") is larger than or equal to the backing-arrays size (" + key.length + ")");
 	}
 
-	private final class EntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC, ObjectSet.ImplementsSpliterator <MAP.Entry KEY_VALUE_GENERIC> {
+	private final class EntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
 
 		// TODO Maybe make this return a list-iterator like the LinkedXHashMaps do? (same for other collection view types)
 
@@ -410,7 +410,7 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 		return oldValue;
 	}
 
-	private final class KeySet extends ABSTRACT_SET KEY_GENERIC implements SET.ImplementsSpliterator KEY_GENERIC {
+	private final class KeySet extends ABSTRACT_SET KEY_GENERIC {
 		@Override
 		public boolean contains(final KEY_TYPE k) {
 			return findKey(k) != -1;
@@ -528,7 +528,7 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 		return keys;
 	}
 
-	private final class ValuesCollection extends VALUE_ABSTRACT_COLLECTION VALUE_GENERIC implements VALUE_COLLECTION.ImplementsSpliterator VALUE_GENERIC {
+	private final class ValuesCollection extends VALUE_ABSTRACT_COLLECTION VALUE_GENERIC {
 		@Override
 		public boolean contains(final VALUE_TYPE v) {
 			return containsValue(v);

--- a/drv/ArraySet.drv
+++ b/drv/ArraySet.drv
@@ -30,7 +30,7 @@ import java.util.function.Consumer;
  * small number of items: just put them into an array and scan linearly to find an item.
  */
 
-public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements SET.ImplementsSpliterator KEY_GENERIC, java.io.Serializable, Cloneable {
+public class ARRAY_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements java.io.Serializable, Cloneable {
 
 	private static final long serialVersionUID = 1L;
 	/** The backing array (valid up to {@link #size}, excluded). */

--- a/drv/BigArrayBigList.drv
+++ b/drv/BigArrayBigList.drv
@@ -51,7 +51,7 @@ import java.util.function.Consumer;
  * @see java.util.ArrayList
  */
 
-public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERIC implements BIG_LIST.ImplementsSpliterator, RandomAccess, Cloneable, java.io.Serializable {
+public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERIC implements RandomAccess, Cloneable, java.io.Serializable {
 	private static final long serialVersionUID = -7046029254386353130L;
 
 
@@ -497,7 +497,7 @@ public class BIG_ARRAY_BIG_LIST KEY_GENERIC extends ABSTRACT_BIG_LIST KEY_GENERI
 		assert size <= BIG_ARRAYS.length(a);
 	}
 
-	private class SubList extends ABSTRACT_BIG_LIST.SUBLIST_RANDOM_ACCESS KEY_GENERIC implements BIG_LIST.ImplementsSpliterator KEY_GENERIC {
+	private class SubList extends ABSTRACT_BIG_LIST.SUBLIST_RANDOM_ACCESS KEY_GENERIC {
 		private static final long serialVersionUID = -3185226345314976296L;
 
 		protected SubList(long from, long to) {

--- a/drv/BigList.drv
+++ b/drv/BigList.drv
@@ -18,13 +18,8 @@
 package PACKAGE;
 
 import java.util.List;
-import java.util.Spliterators;
 import it.unimi.dsi.fastutil.BigList;
 import it.unimi.dsi.fastutil.Size64;
-#if KEY_WIDENED
-import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
-import WIDENED_PACKAGE.WIDENED_SPLITERATORS;
-#endif
 
 #if ! KEY_CLASS_Reference
 
@@ -88,27 +83,8 @@ public interface BIG_LIST KEY_GENERIC extends BigList<KEY_GENERIC_CLASS>, COLLEC
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
 #else
 	default KEY_SPLITERATOR KEY_GENERIC spliterator() {
-#if (defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED) || KEYS_REFERENCE || KEY_CLASS_Boolean
-#if KEY_CLASS_Boolean
-		// TODO See the comment in BooleanCollection about how this is inefficient.
-#endif
-		return SPLITERATORS.AS_KEY_SPLITERATOR(Spliterators.spliterator(
-				iterator(), size64(), SPLITERATORS.LIST_SPLITERATOR_CHARACTERISTICS));
-#else
-		return SPLITERATORS.narrow(KEY_WIDENED_SPLITERATOR_METHOD());
-#endif
-	}
-#endif
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-	@Override
-	default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof COLLECTION.ImplementsSpliterator) {
-			return SPLITERATORS.widen(spliterator());
-		} else {
-			return WIDENED_SPLITERATORS.AS_KEY_WIDENED_SPLITERATOR(Spliterators.spliterator(
-					KEY_WIDENED_ITERATOR_METHOD(), size64(), SPLITERATORS.LIST_SPLITERATOR_CHARACTERISTICS));
-		}
+		return SPLITERATORS.asSpliterator(
+				iterator(), size64(), SPLITERATORS.LIST_SPLITERATOR_CHARACTERISTICS);
 	}
 #endif
 
@@ -290,17 +266,4 @@ public interface BIG_LIST KEY_GENERIC extends BigList<KEY_GENERIC_CLASS>, COLLEC
 #endif
 
 	// Without any toBigArray methods, there is no sensible default sort methods we can have.
-
-	/** Reabstracts the inappropriate {@code spliterator} method from the type-specific big list interface. */
-	public static interface ImplementsSpliterator KEY_GENERIC extends BIG_LIST KEY_GENERIC, COLLECTION.ImplementsSpliterator KEY_GENERIC {
-		// Reabstract the inappropriate default from Collection
-		abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-		default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-			return COLLECTION.ImplementsSpliterator.super.KEY_WIDENED_SPLITERATOR_METHOD();
-		}
-#endif
-	}
-
 }

--- a/drv/Collection.drv
+++ b/drv/Collection.drv
@@ -18,7 +18,6 @@
 package PACKAGE;
 
 import java.util.Collection;
-import java.util.Spliterators;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
 #if KEY_WIDENED
 import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
@@ -61,7 +60,7 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 	 */
 	@Override
 	default KEY_WIDENED_ITERATOR KEY_WIDENED_ITERATOR_METHOD() {
-		return WIDENED_ITERATORS.wrap(iterator());
+		return super.KEY_WIDENED_ITERATOR_METHOD();
 	}
 #elif defined JDK_PRIMITIVE_ITERATOR && KEYS_PRIMITIVE && !KEY_WIDENED && SMALL_TYPES
 	/** Returns a primitive iterator on the elements of this collection.<p>
@@ -82,13 +81,6 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 
 	/** Returns a type-specific spliterator on the elements of this collection.
 	 *
-	 * @implSpec If you are implementing your own primitive collection type and override this method,
-	 * you will likely want have your class additionally implement your specific types'
-	 * {@link ImplementsSpliterator} interface. That will signal to the default methods that
-	 * this type has an explicit spliterator overriden implementation, and thus shouldn't assume
-	 * this this method could call other default methods (allowing other default methods to use
-	 * your spliterator, instead of a default one).
-	 *
 	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}.
 	 *
@@ -100,17 +92,8 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
 #else
 	default KEY_SPLITERATOR KEY_GENERIC spliterator() {
-#if (defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED) || KEYS_REFERENCE || KEY_CLASS_Boolean
-#if KEY_CLASS_Boolean
-		// TODO this default implementation boxes and unboxes, which is not ideal.
-		// But to fix that would require either reimplementing Spliterators.spliterator(Iterable) for BooleanIterable.
-		// Or provide a view to expose BooleanCollection as ints C style and then wrap Spliterators.spliterator(Spliterator.OfInt).
-#endif
-		return SPLITERATORS.AS_KEY_SPLITERATOR(Spliterators.spliterator(
-				iterator(), getSizeOf(this), SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS));
-#else
-		return SPLITERATORS.narrow(KEY_WIDENED_SPLITERATOR_METHOD());
-#endif
+		return SPLITERATORS.asSpliterator(
+				iterator(), getSizeOf(this), SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS);
 	}
 #endif
 
@@ -125,12 +108,7 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 	 */
 	@Override
 	default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof KEY_ITERABLE.ImplementsSpliterator) {
-			return SPLITERATORS.widen(spliterator());
-		} else {
-			return WIDENED_SPLITERATORS.AS_KEY_WIDENED_SPLITERATOR(Spliterators.spliterator(
-					KEY_WIDENED_ITERATOR_METHOD(), getSizeOf(this), SPLITERATORS.COLLECTION_SPLITERATOR_CHARACTERISTICS));
-		}
+		return super.KEY_WIDENED_SPLITERATOR_METHOD();
 	}
 #elif defined JDK_PRIMITIVE_ITERATOR && KEYS_PRIMITIVE && !KEY_WIDENED && SMALL_TYPES
 	/** Returns a primitive spliterator on the elements of this collection.<p>
@@ -332,35 +310,4 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 #endif
 
 #endif
-
-	/** An interface indicating the Collection has an explicit implementation of
-	 * {@link java.util.Collection#spliterator()}, and not a default one. This is accomplished
-	 * by reabstracting the default {@code spliterator} method this type specific collection defines.
-	 *
-	 * <p>This interface is primarily used to signal to a primitive widened spliterator method (e.g
-	 * {@link it.unimi.dsi.fastutil.shorts.ShortCollection#intSpliterator())}
-	 * that it should wrap the result of {@link java.util.Collection#spliterator()}, instead
-	 * of avoiding that because {@code spliterator} could call the widened method.
-	 *
-	 * <p>This interface extends the type-specific Collection interface so that if both appear in
-	 * the list of implemented interfaces, the abstract {@code spliterator()} will take priority
-	 * over the default method. It doesn't logically represent a new kind of Collection. This
-	 * interface should be treated like the abstract classes, used only as an implementation
-	 * aid and not as a variable type.
-	 *
-	 * <p>You generally don't need to worry about this interface unless you are implementing
-	 * your own type-specific Collection class.
-	 */
-	public static interface ImplementsSpliterator KEY_GENERIC extends COLLECTION KEY_GENERIC, KEY_ITERABLE.ImplementsSpliterator KEY_GENERIC {
-		// Reabstract the inappropriate default from Collection
-		@Override
-		abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-		@Override
-		default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-			return SPLITERATORS.widen(spliterator());
-		}
-#endif
-	}
 }

--- a/drv/Iterable.drv
+++ b/drv/Iterable.drv
@@ -18,7 +18,6 @@
 package PACKAGE;
 
 import java.lang.Iterable;
-import java.util.Spliterators;
 #if KEYS_PRIMITIVE
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -111,16 +110,7 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
 #else
 	default KEY_SPLITERATOR KEY_GENERIC spliterator() {
-#if (defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED) || KEYS_REFERENCE || KEY_CLASS_Boolean
-#if KEY_CLASS_Boolean
-		// TODO this default implementation boxes and unboxes, which is not ideal.
-		// But to fix that would require either reimplementing Spliterators.spliterator(Iterable) for BooleanIterable.
-		// Or provide a view to expose BooleanIterable as ints C style and then wrap Spliterators.spliterator(Spliterator.OfInt).
-#endif
-		return SPLITERATORS.AS_KEY_SPLITERATOR(Spliterators.spliteratorUnknownSize(iterator(), 0));
-#else
-		return SPLITERATORS.narrow(KEY_WIDENED_SPLITERATOR_METHOD());
-#endif
+		return SPLITERATORS.asSpliteratorUnknownSize(iterator(), 0); 
 	}
 #endif
 
@@ -130,15 +120,12 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 	 * This method is provided for the purpose of APIs that expect only the JDK's
 	 * primitive spliterators, of which there are only {@code int}, {@code long}, and {@code double}.
 	 *
+	 * @implSpec The default implementation widens the spliterator from {@link #spliterator()}.
 	 * @return a widened primitive spliterator on the elements of this iterable.
 	 * @since 8.3.0
 	 */
 	default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof ImplementsSpliterator) {
-			return SPLITERATORS.widen(spliterator());
-		} else {
-			return WIDENED_SPLITERATORS.AS_KEY_WIDENED_SPLITERATOR(Spliterators.spliteratorUnknownSize(KEY_WIDENED_ITERATOR_METHOD(), 0));
-		}
+		return WIDENED_SPLITERATORS.wrap(spliterator());
 	}
 #elif defined JDK_PRIMITIVE_ITERATOR && KEYS_PRIMITIVE && !KEY_WIDENED && SMALL_TYPES
 	/** Returns a primitive spliterator on the elements of this iterable.<p>
@@ -225,36 +212,5 @@ public interface KEY_ITERABLE KEY_GENERIC extends Iterable<KEY_GENERIC_CLASS> {
 		forEach(action instanceof METHOD_ARG_KEY_CONSUMER ? (METHOD_ARG_KEY_CONSUMER)action : (KEY_CONSUMER) action::accept);
 	}
 #endif
-
-	/** An interface indicating the Iterable has an explicit implementation of
-	 * {@link java.lang.Iterable#spliterator()}, and not a default one. This is accomplished
-	 * by reabstracting the default {@code spliterator} method this type specific collection defines.
-	 *
-	 * <p>This interface is primarily used to signal to a primitive widened spliterator method (e.g
-	 * {@link it.unimi.dsi.fastutil.shorts.ShortIterable#intSpliterator())}
-	 * that it should wrap the result of {@link java.util.Iterable#spliterator()}, instead
-	 * of avoiding that because {@code spliterator} could call the widened method.
-	 *
-	 * <p>This interface extends the type-specific Iterable interface so that if both appear in
-	 * the list of implemented interfaces, the abstract {@code spliterator()} will take priority
-	 * over the default method. It doesn't logically represent a new kind of Iterable. This
-	 * interface should be treated like the abstract classes, used only as an implementation
-	 * aid and not as a variable type.
-	 *
-	 * <p>You generally don't need to worry about this interface unless you are implementing
-	 * your own type-specific Iterable class.
-	 */
-	public static interface ImplementsSpliterator KEY_GENERIC extends KEY_ITERABLE KEY_GENERIC {
-		// Reabstract the inappropriate default from Iterable
-		@Override
-		abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-		@Override
-		default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-			return SPLITERATORS.widen(spliterator());
-		}
-#endif
-	}
 
 }

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -643,7 +643,8 @@ public final class ITERATORS {
 	 * <p><b>WARNING:</b> This is <em>not</em> the same as converting the source to a sequence
 	 * of code points. This returned instance literally performs {@code (int)(charValue)} casts.
 	 * Surrogate pairs will be left as separate elements instead of combined into a single element
-	 * with the code point it represents.
+	 * with the code point it represents. See {@link Character} for more discussion on code points,
+	 * char values, and surrogate pairs.
 	 *
 	 * @param i an iterator
 	 * @return a JDK compatible primitive iterator backed by {@code i}
@@ -1481,7 +1482,8 @@ public final class ITERATORS {
 	 * <p><b>WARNING:</b> This is <em>not</em> the same as converting the source to a sequence
 	 * of code points. This returned instance literally performs {@code (int)(charValue)} casts.
 	 * Surrogate pairs will be left as separate elements instead of combined into a single element
-	 * with the code point it represents.
+	 * with the code point it represents. See {@link Character} for more discussion on code points,
+	 * char values, and surrogate pairs.
 	 *
 	 * @param iterator a char iterator.
 	 * @return an iterator backed by the specified char iterator.

--- a/drv/List.drv
+++ b/drv/List.drv
@@ -18,15 +18,8 @@
 package PACKAGE;
 
 import java.util.List;
-import java.util.Spliterators;
 import java.util.function.Consumer;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
-#if KEY_WIDENED
-import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
-import WIDENED_PACKAGE.WIDENED_ITERATORS;
-import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
-import WIDENED_PACKAGE.WIDENED_SPLITERATORS;
-#endif
 
 #if ! KEY_CLASS_Reference
 
@@ -79,13 +72,6 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @implSpec If you are implementing your own primitive collection type and override this method,
-	 * you will likely want have your class additionally implement the
-	 * {@link ImplementsSpliterator} interface. That will signal to the default methods that
-	 * this type has an explicit spliterator overriden implementation, and thus shouldn't assume
-	 * this this method could call other default methods (allowing other default methods to use
-	 * your spliterator, instead of a default one).
-	 *
 	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}, which was already
 	 * strengthened in the corresponding type-specific class,
@@ -97,27 +83,8 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
 #else
 	default KEY_SPLITERATOR KEY_GENERIC spliterator() {
-#if (defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED) || KEYS_REFERENCE || KEY_CLASS_Boolean
-#if KEY_CLASS_Boolean
-		// TODO See the comment in BooleanCollection about how this is inefficient.
-#endif
-		return SPLITERATORS.AS_KEY_SPLITERATOR(Spliterators.spliterator(
-				iterator(), getSizeOf(this), SPLITERATORS.LIST_SPLITERATOR_CHARACTERISTICS));
-#else
-		return SPLITERATORS.narrow(KEY_WIDENED_SPLITERATOR_METHOD());
-#endif
-	}
-#endif
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-	@Override
-	default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof KEY_ITERABLE.ImplementsSpliterator) {
-			return SPLITERATORS.widen(spliterator());
-		} else {
-			return WIDENED_SPLITERATORS.AS_KEY_WIDENED_SPLITERATOR(Spliterators.spliterator(
-					KEY_WIDENED_ITERATOR_METHOD(), getSizeOf(this), SPLITERATORS.LIST_SPLITERATOR_CHARACTERISTICS));
-		}
+		return SPLITERATORS.asSpliterator(
+				iterator(), getSizeOf(this), SPLITERATORS.LIST_SPLITERATOR_CHARACTERISTICS);
 	}
 #endif
 
@@ -502,18 +469,4 @@ public interface LIST KEY_GENERIC extends List<KEY_GENERIC_CLASS>, COLLECTION KE
 		setElements(elements);
 	}
 #endif
-
-	/** Reabstracts the inappropriate {@code spliterator} method from the type-specific list interface. */
-	public static interface ImplementsSpliterator KEY_GENERIC extends LIST KEY_GENERIC, COLLECTION.ImplementsSpliterator KEY_GENERIC {
-		// Reabstract the inappropriate default from Collection
-		@Override
-		abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-		@Override
-		default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-			return COLLECTION.ImplementsSpliterator.super.KEY_WIDENED_SPLITERATOR_METHOD();
-		}
-#endif
-	}
 }

--- a/drv/OpenHashBigSet.drv
+++ b/drv/OpenHashBigSet.drv
@@ -57,7 +57,7 @@ import java.util.NoSuchElementException;
  * @see HashCommon
  */
 
-public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements SET.ImplementsSpliterator KEY_GENERIC, java.io.Serializable, Cloneable, Hash, Size64 {
+public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements java.io.Serializable, Cloneable, Hash, Size64 {
 
 	private static final long serialVersionUID = 0L;
 	private static final boolean ASSERTS = ASSERTS_VALUE;

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -2033,8 +2033,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		 */
 		@Override
 		public ObjectSpliterator<MAP.Entry KEY_VALUE_GENERIC> spliterator() {
-			return ObjectSpliterators.asObjectSpliterator(java.util.Spliterators.spliterator(
-				iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS));
+			return ObjectSpliterators.asSpliterator(
+				iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS);
 		}
 
 		@Override
@@ -2334,8 +2334,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		 * @see EntrySet#spliterator()
 		 */
 		public KEY_SPLITERATOR KEY_GENERIC spliterator() {
-			return SPLITERATORS.AS_KEY_SPLITERATOR(java.util.Spliterators.spliterator(
-				iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS));
+			return SPLITERATORS.asSpliterator(
+				iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS);
 		}
 
 #else
@@ -2482,8 +2482,8 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 				 */
 				@Override
 				public VALUE_SPLITERATOR VALUE_GENERIC spliterator() {
-					return VALUE_SPLITERATORS.AS_VALUE_SPLITERATOR(java.util.Spliterators.spliterator(
-						iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS));
+					return VALUE_SPLITERATORS.asSpliterator(
+						iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(OPEN_HASH_MAP.this), SPLITERATOR_CHARACTERISTICS);
 				}
 #else
 				@Override

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -83,7 +83,7 @@ import java.util.Comparator;
  * @see HashCommon
  */
 
-public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC implements SORTED_SET.ImplementsSpliterator KEY_GENERIC, java.io.Serializable, Cloneable, Hash {
+public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC implements java.io.Serializable, Cloneable, Hash {
 
 #else
 
@@ -111,7 +111,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SORTED_SET KEY_GENERIC i
  * @see HashCommon
  */
 
-public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements SET.ImplementsSpliterator KEY_GENERIC, java.io.Serializable, Cloneable, Hash {
+public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements java.io.Serializable, Cloneable, Hash {
 
 #else
 
@@ -136,7 +136,7 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
  * @see HashCommon
  */
 
-public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements SET.ImplementsSpliterator KEY_GENERIC, java.io.Serializable, Cloneable, Hash {
+public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implements java.io.Serializable, Cloneable, Hash {
 
 #endif
 
@@ -1381,8 +1381,8 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 	 */
 	@Override
 	public KEY_SPLITERATOR spliterator() {
-		return SPLITERATORS.AS_KEY_SPLITERATOR(java.util.Spliterators.spliterator(
-			iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(this), SPLITERATOR_CHARACTERISTICS));
+		return SPLITERATORS.asSpliterator(
+			iterator(), it.unimi.dsi.fastutil.Size64.getSizeOf(this), SPLITERATOR_CHARACTERISTICS);
 	}
 
 	@Override

--- a/drv/Set.drv
+++ b/drv/Set.drv
@@ -18,14 +18,7 @@
 package PACKAGE;
 
 import java.util.Set;
-import java.util.Spliterators;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
-#if KEY_WIDENED
-import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
-import WIDENED_PACKAGE.WIDENED_ITERATORS;
-import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
-import WIDENED_PACKAGE.WIDENED_SPLITERATORS;
-#endif
 
 /** A type-specific {@link Set}; provides some additional methods that use polymorphism to avoid (un)boxing.
  *
@@ -50,13 +43,6 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @implSpec If you are implementing your own primitive collection type and override this method,
-	 * you will likely want have your class additionally implement the
-	 * {@link ImplementsSpliterator} interface. That will signal to the default methods that
-	 * this type has an explicit spliterator overriden implementation, and thus shouldn't assume
-	 * this this method could call other default methods (allowing other default methods to use
-	 * your spliterator, instead of a default one).
-	 *
 	 * @implSpec This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}, which was already
 	 * strengthened in the corresponding type-specific class,
@@ -67,27 +53,8 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
 #else
 	default KEY_SPLITERATOR KEY_GENERIC spliterator() {
-#if (defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED) || KEYS_REFERENCE || KEY_CLASS_Boolean
-#if KEY_CLASS_Boolean
-		// TODO See the comment in BooleanCollection about how this is inefficient.
-#endif
-		return SPLITERATORS.AS_KEY_SPLITERATOR(Spliterators.spliterator(
-				iterator(), getSizeOf(this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS));
-#else
-		return SPLITERATORS.narrow(KEY_WIDENED_SPLITERATOR_METHOD());
-#endif
-	}
-#endif
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-	@Override
-	default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof KEY_ITERABLE.ImplementsSpliterator) {
-			return SPLITERATORS.widen(spliterator());
-		} else {
-			return WIDENED_SPLITERATORS.AS_KEY_WIDENED_SPLITERATOR(Spliterators.spliterator(
-					KEY_WIDENED_ITERATOR_METHOD(), getSizeOf(this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS));
-		}
+		return SPLITERATORS.asSpliterator(
+				iterator(), getSizeOf(this), SPLITERATORS.SET_SPLITERATOR_CHARACTERISTICS);
 	}
 #endif
 
@@ -147,18 +114,4 @@ public interface SET KEY_GENERIC extends COLLECTION KEY_GENERIC, Set<KEY_GENERIC
 	}
 
 #endif
-
-	/** Reabstracts the inappropriate {@code spliterator} method from the type-specific set interface. */
-	public static interface ImplementsSpliterator KEY_GENERIC extends SET KEY_GENERIC, COLLECTION.ImplementsSpliterator KEY_GENERIC {
-		// Reabstract the inappropriate default from Collection
-		@Override
-		abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-		@Override
-		default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-			return COLLECTION.ImplementsSpliterator.super.KEY_WIDENED_SPLITERATOR_METHOD();
-		}
-#endif
-	}
 }

--- a/drv/SortedSet.drv
+++ b/drv/SortedSet.drv
@@ -19,14 +19,7 @@ package PACKAGE;
 
 import java.util.SortedSet;
 import java.util.Collection;
-import java.util.Spliterators;
 import static it.unimi.dsi.fastutil.Size64.getSizeOf;
-#if KEY_WIDENED
-import WIDENED_PACKAGE.KEY_WIDENED_ITERATOR;
-import WIDENED_PACKAGE.WIDENED_ITERATORS;
-import WIDENED_PACKAGE.KEY_WIDENED_SPLITERATOR;
-import WIDENED_PACKAGE.WIDENED_SPLITERATORS;
-#endif
 
 
 /** A type-specific {@link SortedSet}; provides some additional methods that use polymorphism to avoid (un)boxing.
@@ -86,13 +79,6 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @implSpec If you are implementing your own primitive collection type and override this method,
-	 * you will likely want have your class additionally implement the
-	 * {@link ImplementsSpliterator} interface. That will signal to the default methods that
-	 * this type has an explicit spliterator overriden implementation, and thus shouldn't assume
-	 * this this method could call other default methods (allowing other default methods to use
-	 * your spliterator, instead of a default one).
-	 *
 	 * @apiNote This specification strengthens the one given in
 	 * {@link java.util.Collection#spliterator()}, which was already
 	 * strengthened in the corresponding type-specific class,
@@ -103,28 +89,7 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
 #else
 	default KEY_SPLITERATOR KEY_GENERIC spliterator() {
-#if (defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED) || KEYS_REFERENCE || KEY_CLASS_Boolean
-#if KEY_CLASS_Boolean
-		// TODO See the comment in BooleanCollection about how this is inefficient.
-#endif
-		return SPLITERATORS.AS_KEY_SPLITERATOR(
-			Spliterators.spliterator(iterator(), getSizeOf(this), SPLITERATORS.SORTED_SET_SPLITERATOR_CHARACTERISTICS), comparator());
-#else
-		return SPLITERATORS.narrow(KEY_WIDENED_SPLITERATOR_METHOD());
-#endif
-	}
-#endif
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-	@Override
-	default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-		if (this instanceof KEY_ITERABLE.ImplementsSpliterator) {
-			return SPLITERATORS.widen(spliterator());
-		} else {
-		return WIDENED_SPLITERATORS.AS_KEY_WIDENED_SPLITERATOR(
-			Spliterators.spliterator(KEY_WIDENED_ITERATOR_METHOD(), getSizeOf(this), SPLITERATORS.SORTED_SET_SPLITERATOR_CHARACTERISTICS),
-			(KEY_TYPE_WIDENED left, KEY_TYPE_WIDENED right) -> comparator().compare(KEY_NARROWING(left), KEY_NARROWING(right)));
-		}
+		return SPLITERATORS.asSpliteratorFromSorted(iterator(), getSizeOf(this), SPLITERATORS.SORTED_SET_SPLITERATOR_CHARACTERISTICS, comparator());
 	}
 #endif
 
@@ -221,18 +186,4 @@ public interface SORTED_SET KEY_GENERIC extends SET KEY_GENERIC, SortedSet<KEY_G
 	}
 
 #endif
-
-	/** Reabstracts the inappropriate {@code spliterator} method from the type-specific sorted set interface. */
-	public static interface ImplementsSpliterator KEY_GENERIC extends SORTED_SET KEY_GENERIC, SET.ImplementsSpliterator KEY_GENERIC {
-		// Reabstract the inappropriate default from Collection
-		@Override
-		abstract KEY_SPLITERATOR KEY_GENERIC spliterator();
-
-#if defined JDK_PRIMITIVE_SPLITERATOR && KEY_WIDENED
-		@Override
-		default KEY_WIDENED_SPLITERATOR KEY_WIDENED_SPLITERATOR_METHOD() {
-			return SET.ImplementsSpliterator.super.KEY_WIDENED_SPLITERATOR_METHOD();
-		}
-#endif
-	}
 }

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -20,6 +20,7 @@ package PACKAGE;
 import java.util.Spliterator;
 import java.util.Objects;
 import java.util.function.Consumer;
+import it.unimi.dsi.fastutil.SafeMath;
 #if KEYS_REFERENCE
 import java.util.Comparator;
 #endif
@@ -39,19 +40,22 @@ public final class SPLITERATORS {
 
 	private SPLITERATORS() {}
 
-	// Default characteristics for various Collection implementations
-	public static final int COLLECTION_SPLITERATOR_CHARACTERISTICS = Spliterator.SIZED
 #if KEYS_PRIMITIVE
-			| Spliterator.NONNULL;
+	static final int BASE_SPLITERATOR_CHARACTERISTICS = Spliterator.NONNULL;
 #else
-			;
+	static final int BASE_SPLITERATOR_CHARACTERISTICS = 0;
 #endif
+
+	// Default characteristics for various Collection implementations
+	public static final int COLLECTION_SPLITERATOR_CHARACTERISTICS = BASE_SPLITERATOR_CHARACTERISTICS | Spliterator.SIZED;
 
 	public static final int LIST_SPLITERATOR_CHARACTERISTICS = COLLECTION_SPLITERATOR_CHARACTERISTICS | Spliterator.ORDERED | Spliterator.SUBSIZED;
 
 	public static final int SET_SPLITERATOR_CHARACTERISTICS = COLLECTION_SPLITERATOR_CHARACTERISTICS | Spliterator.DISTINCT;
 
-	public static final int SORTED_SET_SPLITERATOR_CHARACTERISTICS = SET_SPLITERATOR_CHARACTERISTICS | Spliterator.SORTED | Spliterator.ORDERED;
+	private static final int SORTED_CHARACTERISTICS = Spliterator.ORDERED | Spliterator.SORTED;
+
+	public static final int SORTED_SET_SPLITERATOR_CHARACTERISTICS = SET_SPLITERATOR_CHARACTERISTICS | SORTED_CHARACTERISTICS;	
 
 	/** A class returning no elements and a type-specific spliterator interface.
 	 *
@@ -221,21 +225,23 @@ public final class SPLITERATORS {
 
 	private static class ArraySpliterator KEY_GENERIC implements KEY_SPLITERATOR KEY_GENERIC {
 
-		private static final int CHARACTERISTICS =
+		private static final int BASE_CHARACTERISTICS =
 			Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED
 #if KEYS_PRIMITIVE
 			| Spliterator.NONNULL
 #endif
 		;
 
-		private final KEY_GENERIC_TYPE[] array;
+		final KEY_GENERIC_TYPE[] array;
 		private final int offset;
 		private int length, curr;
+		final int characteristics;
 
-		public ArraySpliterator(final KEY_GENERIC_TYPE[] array, final int offset, final int length) {
+		public ArraySpliterator(final KEY_GENERIC_TYPE[] array, final int offset, final int length, int additionalCharacteristics) {
 			this.array = array;
 			this.offset = offset;
 			this.length = length;
+			characteristics = BASE_CHARACTERISTICS | additionalCharacteristics;
 		}
 
 		@Override
@@ -247,9 +253,21 @@ public final class SPLITERATORS {
 		}
 
 		@Override
+		public void forEachRemaining(METHOD_ARG_KEY_CONSUMER action) {
+			Objects.requireNonNull(action);
+			while (curr < length) {
+				action.accept(array[offset + curr++]);
+			}
+		}
+
+		@Override
 		public long estimateSize() { return length - curr; }
 		@Override
-		public int characteristics() { return CHARACTERISTICS; }
+		public int characteristics() { return characteristics; }
+		
+		protected ArraySpliterator KEY_GENERIC makeForSplit(int newOffset, int newLength) {
+			return new ArraySpliterator KEY_GENERIC_DIAMOND(array, newOffset, newLength, characteristics);
+		}
 
 		@Override
 		public KEY_SPLITERATOR KEY_GENERIC trySplit() {
@@ -260,7 +278,7 @@ public final class SPLITERATORS {
 			// int myNewLength = length - retLength;
 			this.curr = myNewCurr;
 			// this.length = myNewLength;
-			return new ArraySpliterator KEY_GENERIC_DIAMOND(array, retOffset, retLength);
+			return makeForSplit(retOffset, retLength);
 		}
 
 		@Override
@@ -281,7 +299,7 @@ public final class SPLITERATORS {
 			if (curr >= length) return 0;
 			final int remaining = length - curr;
 			if (n < remaining) {
-				curr = it.unimi.dsi.fastutil.SafeMath.safeLongToInt(curr + n);
+				curr = SafeMath.safeLongToInt(curr + n);
 				return n;
 			}
 			n = remaining;
@@ -290,12 +308,29 @@ public final class SPLITERATORS {
 		}
 	}
 
+	private static class ArraySpliteratorWithComparator KEY_GENERIC extends ArraySpliterator KEY_GENERIC {
+		private final KEY_COMPARATOR KEY_SUPER_GENERIC comparator;
+	
+		public ArraySpliteratorWithComparator(final KEY_GENERIC_TYPE[] array, final int offset, final int length, int additionalCharacteristics, final KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+			super(array, offset, length, additionalCharacteristics | SORTED_CHARACTERISTICS);
+			this.comparator = comparator;
+		}
+
+		@Override
+		protected ArraySpliteratorWithComparator KEY_GENERIC makeForSplit(int newOffset, int newLength) {
+			return new ArraySpliteratorWithComparator KEY_GENERIC_DIAMOND(array, newOffset, newLength, characteristics, comparator);
+		}
+	}
 
 	/** Wraps the given part of an array into a type-specific spliterator.
 	 *
 	 * <p>The type-specific spliterator returned by this method will iterate
 	 * {@code length} times, advancing over consecutive elements of the given
 	 * array starting from the one with index {@code offset}.
+	 *
+	 * <p>The returned spliterator will report {@link Spliterator.characteristics() characteristics}
+	 * {@link Spliterator.SIZED}, {@link Spliterator.SUBSIZED},
+	 * {@link Spliterator.ORDERED}, and for primitive arrays, {@link Spliterator.NONNULL}.
 	 *
 	 * @param array an array to wrap into a type-specific spliterator.
 	 * @param offset the first element of the array to be returned.
@@ -304,7 +339,7 @@ public final class SPLITERATORS {
 	 */
 	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC wrap(final KEY_GENERIC_TYPE[] array, final int offset, final int length) {
 		ARRAYS.ensureOffsetLength(array, offset, length);
-		return new ArraySpliterator KEY_GENERIC_DIAMOND(array, offset, length);
+		return new ArraySpliterator KEY_GENERIC_DIAMOND(array, offset, length, 0);
 	}
 
 	/** Wraps the given array into a type-specific spliterator.
@@ -312,12 +347,122 @@ public final class SPLITERATORS {
 	 * <p>The type-specific spliterator returned by this method will advance over
 	 * all elements of the given array.
 	 *
+	 * <p>The returned spliterator will report {@link Spliterator.characteristics() characteristics}
+	 * {@link Spliterator.SIZED}, {@link Spliterator.SUBSIZED},
+	 * {@link Spliterator.ORDERED}, and for primitive arrays, {@link Spliterator.NONNULL}.
+	 *
 	 * @param array an array to wrap into a type-specific spliterator.
 	 * @return a spliterator that will iterate over the elements of {@code array}.
 	 */
 	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC wrap(final KEY_GENERIC_TYPE[] array) {
-		return new ArraySpliterator KEY_GENERIC_DIAMOND(array, 0, array.length);
+		return new ArraySpliterator KEY_GENERIC_DIAMOND(array, 0, array.length, 0);
 	}
+	
+	/** Wraps the given part of an array into a type-specific spliterator.
+	 *
+	 * <p>The type-specific spliterator returned by this method will iterate
+	 * {@code length} times, advancing over consecutive elements of the given
+	 * array starting from the one with index {@code offset}.
+	 *
+	 * <p>The returned spliterator will report {@link Spliterator.characteristics() characteristics}
+	 * {@link Spliterator.SIZED}, {@link Spliterator.SUBSIZED},
+	 * {@link Spliterator.ORDERED}, and for primitive arrays, {@link Spliterator.NONNULL},
+	 * on top of any additional characteristics given in {@code additionalCharacteristics} (for example, if
+	 * the caller knows the backing array is sorted, they can pass {@link Spliterator.SORTED}). 
+	 *
+	 * @param array an array to wrap into a type-specific spliterator.
+	 * @param offset the first element of the array to be returned.
+	 * @param length the number of elements to return.
+	 * @param additionalCharacteristics any additional characteristics to report.
+	 * @return a spliterator that will iterate over {@code length} elements of {@code array} starting at position {@code offset}.
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC wrap(final KEY_GENERIC_TYPE[] array, final int offset, final int length, final int additionalCharacteristics) {
+		ARRAYS.ensureOffsetLength(array, offset, length);
+		return new ArraySpliterator KEY_GENERIC_DIAMOND(array, offset, length, additionalCharacteristics);
+	}
+
+	/** Wraps the given part of a sorted array into a type-specific spliterator.
+	 *
+	 * <p>It is the caller's responsibility to ensure the array is actually sorted using
+	 * the comparator given.
+	 *
+	 * <p>The type-specific spliterator returned by this method will iterate
+	 * {@code length} times, advancing over consecutive elements of the given
+	 * array starting from the one with index {@code offset}.
+	 *
+	 * <p>The returned spliterator will report {@link Spliterator.characteristics() characteristics}
+	 * {@link Spliterator.SIZED}, {@link Spliterator.SUBSIZED},
+	 * {@link Spliterator.ORDERED}, {@link Spliterator.SORTED}, and for primitive arrays,
+	 * {@link Spliterator.NONNULL},
+	 * on top of any additional characteristics given in {@code additionalCharacteristics} (for example, if
+	 * the caller knows the backing array has distinct elements, they can pass {@link Spliterator.DISTINCT}). 
+	 *
+	 * @param array an array to wrap into a type-specific spliterator.
+	 * @param offset the first element of the array to be returned.
+	 * @param length the number of elements to return.
+	 * @param additionalCharacteristics any additional characteristics to report.
+	 * @param comparator the comparator the array was sorted with (or {@code null} for natural ordering)
+	 * @return a spliterator that will iterate over {@code length} elements of {@code array} starting at position {@code offset}.
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC wrapPreSorted(
+			final KEY_GENERIC_TYPE[] array, final int offset, final int length, final int additionalCharacteristics, KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+		ARRAYS.ensureOffsetLength(array, offset, length);
+		return new ArraySpliteratorWithComparator KEY_GENERIC_DIAMOND(array, offset, length, additionalCharacteristics, comparator);
+	}
+
+	/** Wraps the given part of a sorted array into a type-specific spliterator.
+	 *
+	 * <p>It is the caller's responsibility to ensure the array is actually sorted using
+	 * the comparator given.
+	 *
+	 * <p>The type-specific spliterator returned by this method will iterate
+	 * {@code length} times, advancing over consecutive elements of the given
+	 * array starting from the one with index {@code offset}.
+	 *
+	 * <p>The returned spliterator will report {@link Spliterator.characteristics() characteristics}
+	 * {@link Spliterator.SIZED}, {@link Spliterator.SUBSIZED},
+	 * {@link Spliterator.ORDERED}, {@link Spliterator.SORTED}, and for primitive arrays,
+	 * {@link Spliterator.NONNULL}.
+	 *
+	 * @param array an array to wrap into a type-specific spliterator.
+	 * @param offset the first element of the array to be returned.
+	 * @param length the number of elements to return.
+	 * @param comparator the comparator the array was sorted with (or {@code null} for natural ordering)
+	 * @return a spliterator that will iterate over {@code length} elements of {@code array} starting at position {@code offset}.
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC wrapPreSorted(
+			final KEY_GENERIC_TYPE[] array, final int offset, final int length, KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+		return wrapPreSorted(array, offset, length, 0, comparator);
+	}
+
+	/** Wraps the given sorted array into a type-specific spliterator.
+	 *
+	 * <p>It is the caller's responsibility to ensure the array is actually sorted using
+	 * the comparator given.
+	 *
+	 * <p>The type-specific spliterator returned by this method will advance over
+	 * all elements of the given array.
+	 *
+	 * <p>The returned spliterator will report {@link Spliterator.characteristics() characteristics}
+	 * {@link Spliterator.SIZED}, {@link Spliterator.SUBSIZED},
+	 * {@link Spliterator.ORDERED}, {@link Spliterator.SORTED}, and for primitive arrays,
+	 * {@link Spliterator.NONNULL}.
+	 *
+	 * @param array an array to wrap into a type-specific spliterator.
+	 * @param comparator the comparator the array was sorted with (or {@code null} for natural ordering)
+	 * @return a spliterator that will iterate over {@code length} elements of {@code array} starting at position {@code offset}.
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC wrapPreSorted(
+			final KEY_GENERIC_TYPE[] array, KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+		return wrapPreSorted(array, 0, array.length, comparator);
+	}
+
+	// There is no non-comparator version of wrapPreSorted; because Spliterator has to return the Comparator
+	// it is ordered with respect to, the caller should think about the Spliterator they use.
 
 	// wrap, unwrap, and pour are not provided because if you are using Spliterators, you typically
 	// are going to be using streams. That and Spliterator's API isn't well suited for these
@@ -690,7 +835,7 @@ public final class SPLITERATORS {
 		 * <p>Do <em>not</em> modify {@link #pos} in this method; the default {@link #trySplit()}
 		 * method takes care of this.
 		 *
-		 * <p>To comply with the spec of {@link java.util.Spliterator#ORDERED}, this will
+		 * <p>To comply with the spec of {@link Spliterator#ORDERED}, this will
 		 * only be called to create prefixes of the current sequence this spliterator is over,
 		 * and this instance will start at the end of the returned sequence and have the same
 		 * end point.
@@ -762,7 +907,7 @@ public final class SPLITERATORS {
 			if (pos >= max) return 0;
 			final int remaining = max - pos;
 			if (n < remaining) {
-				pos = it.unimi.dsi.fastutil.SafeMath.safeLongToInt(pos + n);
+				pos = SafeMath.safeLongToInt(pos + n);
 				return n;
 			}
 			n = remaining;
@@ -1196,6 +1341,325 @@ public final class SPLITERATORS {
 		return new SpliteratorConcatenator KEY_GENERIC_DIAMOND(a, offset, length);
 	}
 
+	private static class SpliteratorFromIterator KEY_GENERIC implements KEY_SPLITERATOR KEY_GENERIC {
+		// TODO Expose this arithmetically incrementing split size logic as an abstract class.
+		// Like java.util.Spliterators.AbstractSpliterator?
+		private static final int BATCH_INCREMENT_SIZE = 1024;
+		private static final int BATCH_MAX_SIZE = 1 << 25;
+
+		private final KEY_ITERATOR KEY_EXTENDS_GENERIC iter;
+		final int characteristics;
+		private final boolean knownSize;
+		/** If {@code knownSize}, then has the remaining size left.
+		 * Otherwise the value of this variable has no meaning.
+		 */
+		private long size = Long.MAX_VALUE;
+		private int nextBatchSize = BATCH_INCREMENT_SIZE;
+
+		/** Used to "finish off" elements once we hit the end while splitting. */
+		private KEY_SPLITERATOR KEY_GENERIC delegate = null;
+
+		SpliteratorFromIterator(final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, int characteristics) {
+			this.iter = iter;
+			this.characteristics = BASE_SPLITERATOR_CHARACTERISTICS | characteristics;
+			knownSize = false;
+		}
+
+		SpliteratorFromIterator(final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, long size, int additionalCharacteristics) {
+			this.iter = iter;
+			knownSize = true;
+			this.size = size;
+			if ((additionalCharacteristics & Spliterator.CONCURRENT) != 0) {
+				this.characteristics = BASE_SPLITERATOR_CHARACTERISTICS | additionalCharacteristics;
+			} else {
+				this.characteristics = Spliterator.SIZED | Spliterator.SUBSIZED | BASE_SPLITERATOR_CHARACTERISTICS | additionalCharacteristics;
+			}
+		}
+
+		@Override
+		public boolean tryAdvance(final METHOD_ARG_KEY_CONSUMER action) {
+			if (delegate != null){
+				boolean hadRemaining = delegate.tryAdvance(action);
+				if (!hadRemaining) delegate = null;
+				return hadRemaining;
+			}
+			if (!iter.hasNext()) return false;
+			--size;
+			action.accept(iter.NEXT_KEY());
+			return true;
+		}
+
+		@Override
+		public void forEachRemaining(final METHOD_ARG_KEY_CONSUMER action) {
+			if (delegate != null) {
+				delegate.forEachRemaining(action);
+				delegate = null;
+			} else {
+				iter.forEachRemaining(action);
+				size = 0;
+			}
+		}
+
+		@Override
+		public long estimateSize() {
+			if (delegate != null) return delegate.estimateSize();
+			if (!iter.hasNext()) return 0;
+			// Size can be less then or equal to zero yet still have next if the iterator
+			// was concurrently modified, in which case we don't know anymore.
+			return knownSize && size >= 0 ? size : Long.MAX_VALUE;
+		}
+
+		@Override
+		public int characteristics() {
+			return characteristics;
+		}
+		
+		protected KEY_SPLITERATOR KEY_GENERIC makeForSplit(KEY_GENERIC_TYPE[] batch, int len) {
+			return wrap(batch, 0, len, characteristics);
+		}
+
+		@Override
+		public KEY_SPLITERATOR KEY_GENERIC trySplit() {
+			if (!iter.hasNext()) return null;
+			int batchSizeEst = knownSize && size > 0 ? (int)Math.min(nextBatchSize, size) : nextBatchSize;
+			SUPPRESS_WARNINGS_KEY_UNCHECKED
+			KEY_GENERIC_TYPE[] batch = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[batchSizeEst];
+			int actualSeen = 0;
+			while (actualSeen < batchSizeEst && iter.hasNext()) {
+				batch[actualSeen++] = iter.NEXT_KEY();
+				--size;
+			}
+			// Check if the local size variable fell behind the backing source, and if so, fill up remaining of batch
+			if (batchSizeEst < nextBatchSize && iter.hasNext()) {
+				batch = java.util.Arrays.copyOf(batch, nextBatchSize);
+				while (iter.hasNext() && actualSeen < nextBatchSize) {
+					batch[actualSeen++] = iter.NEXT_KEY();
+					--size;
+				}
+			}
+			nextBatchSize = Math.min(BATCH_MAX_SIZE, nextBatchSize + BATCH_INCREMENT_SIZE);
+			
+			// If we have none remaining, then set our delegate to "finish off" the batch we just made.
+			KEY_SPLITERATOR KEY_GENERIC split = makeForSplit(batch, actualSeen); 
+			if (!iter.hasNext()) {
+				delegate = split;
+				return split.trySplit();
+			} else {
+				return split;
+			}
+		}
+
+		@Override
+		public long skip(long n) {
+			if (n < 0) throw new IllegalArgumentException("Argument must be nonnegative: " + n);
+			if (iter instanceof KEY_BIG_LIST_ITERATOR) {
+				long skipped = ((KEY_BIG_LIST_ITERATOR KEY_EXTENDS_GENERIC)iter).skip(n);
+				size -= skipped;
+				return skipped;
+			} else {
+				long skippedSoFar = 0;
+				while (skippedSoFar < n && iter.hasNext()) {
+					int skipped = iter.skip(SafeMath.safeLongToInt(Math.min(n, Integer.MAX_VALUE)));
+					size -= skipped;
+					skippedSoFar += skipped;
+				}
+				return skippedSoFar;
+			}
+		}
+	}
+
+	private static class SpliteratorFromIteratorWithComparator KEY_GENERIC extends SpliteratorFromIterator KEY_GENERIC { 
+	
+		private final KEY_COMPARATOR KEY_SUPER_GENERIC comparator;
+		
+		SpliteratorFromIteratorWithComparator(final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, int additionalCharacteristics, final KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+			super(iter, additionalCharacteristics | SORTED_CHARACTERISTICS);
+			this.comparator = comparator;
+		}
+
+		SpliteratorFromIteratorWithComparator(final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, long size, int additionalCharacteristics, final KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+			super(iter, size, additionalCharacteristics | SORTED_CHARACTERISTICS);
+			this.comparator = comparator;
+		}
+		
+		@Override
+		public KEY_COMPARATOR KEY_SUPER_GENERIC getComparator() {
+			return comparator;
+		}
+
+		@Override
+		protected KEY_SPLITERATOR KEY_GENERIC makeForSplit(KEY_GENERIC_TYPE[] array, int len) {
+			return wrapPreSorted(array, 0, len, characteristics, comparator);
+		}
+	}
+
+	/** Wrap a type-specific {@link java.util.Iterator} of a known size as a type-specific {@link java.util.Spliterator}
+	 *
+	 * <p>The returned spliterator will report
+	 * {@link java.util.Spliterator.characteristics() characteristics} {@code additionalCharacterisitcs},
+	 * and for primitive types, {@link Spliterator.NONNULL}.
+	 * It will also report {@link java.util.Spliterator.SIZED}, {@link java.util.Spliterator.SUBSIZED},
+	 * unless {@link java.util.Spliterator.CONCURRENT} is to be reported, in which case these two
+	 * are not implicitly reported.
+	 *
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
+	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
+	 * expensive. 
+	 *
+	 * @param iter the type-specific {@code Iterator} to wrap
+	 * @param size the number of elements the iterator will return
+	 * @param additionalCharacterisitcs any additional characteristics to report
+	 * @return a type-specific {@code Spliterator} that will give the same elements the iterator will return.
+	 * @see java.util.Spliterators.spliterator(java.util.Iterator, long, int)
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC asSpliterator(final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, final long size, final int additionalCharacterisitcs) {
+		return new SpliteratorFromIterator KEY_GENERIC_DIAMOND(iter, size, additionalCharacterisitcs);
+	}
+
+	/** Wrap a type-specific, sorted {@link java.util.Iterator} of a known size as a type-specific {@link java.util.Spliterator}
+	 *
+	 * <p>It is the caller's responsibility to ensure the iterator's order
+	 * is actually sorted according to the comparator given.
+	 *
+	 * <p>The returned spliterator will report
+	 * {@link java.util.Spliterator.characteristics() characteristics} {@code additionalCharacterisitcs},
+	 * {@link java.util.Spliterator.ORDERED}, {@link java.util.Spliterator.SORTED}, and for primitive types,
+	 * {@link Spliterator.NONNULL}.
+	 * It will also report {@link java.util.Spliterator.SIZED}, {@link java.util.Spliterator.SUBSIZED},
+	 * unless {@link java.util.Spliterator.CONCURRENT} is to be reported, in which case these two
+	 * are not implicitly reported.
+	 *
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
+	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
+	 * expensive. 
+	 *
+	 * @param iter the type-specific {@code Iterator} to wrap
+	 * @param size the number of elements the iterator will return
+	 * @param additionalCharacterisitcs any additional characteristics to report
+	 * @param comparator the comparator the iterator is ordered on (or {@code null} for natural ordering)
+	 * @return a type-specific {@code Spliterator} that will give the same elements the iterator will return.
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC asSpliteratorFromSorted(
+			final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, final long size, final int additionalCharacterisitcs, final KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+		return new SpliteratorFromIteratorWithComparator KEY_GENERIC_DIAMOND(iter, size, additionalCharacterisitcs, comparator);
+	}
+
+	/** Wrap a type-specific {@link java.util.Iterator} of an unknown size as a type-specific {@link java.util.Spliterator}
+	 *
+	 * <p>The returned spliterator will report{@code additionalCharacterisitcs},
+	 * and for primitive types, {@link Spliterator.NONNULL}.
+	 * 
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
+	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
+	 * expensive. 
+	 *
+	 * @param iter the type-specific {@code Iterator} to wrap
+	 * @param characterisitcs the characteristics to report
+	 * @return a type-specific {@code Spliterator} that will give the same elements the iterator will return.
+	 * @see java.util.Spliterators.spliteratorUnknownSize(java.util.Iterator, int)
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC asSpliteratorUnknownSize(final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, final int additionalCharacterisitcs) {
+		return new SpliteratorFromIterator KEY_GENERIC_DIAMOND(iter, additionalCharacterisitcs);
+	}
+
+	/** Wrap a type-specific, sorted {@link java.util.Iterator} of an unknown size as a type-specific {@link java.util.Spliterator}
+	 *
+	 * <p>It is the caller's responsibility to ensure the iterator's order
+	 * is actually sorted according to the comparator given.
+	 *
+	 * <p>The returned spliterator will report
+	 * {@link java.util.Spliterator.characteristics() characteristics} {@code additionalCharacterisitcs},
+	 * {@link java.util.Spliterator.ORDERED}, {@link java.util.Spliterator.SORTED}, and for primitive types,
+	 * {@link Spliterator.NONNULL}.
+	 *
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
+	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
+	 * expensive. 
+	 *
+	 * @param iter the type-specific {@code Iterator} to wrap
+	 * @param additionalCharacterisitcs the characteristics to report
+	 * @param comparator the comparator the iterator is ordered on (or {@code null} for natural ordering)
+	 * @return a type-specific {@code Spliterator} that will give the same elements the iterator will return.
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_SPLITERATOR KEY_GENERIC asSpliteratorFromSortedUnknownSize(final KEY_ITERATOR KEY_EXTENDS_GENERIC iter, final int additionalCharacterisitcs, final KEY_COMPARATOR KEY_SUPER_GENERIC comparator) {
+		return new SpliteratorFromIteratorWithComparator KEY_GENERIC_DIAMOND(iter, additionalCharacterisitcs, comparator);
+	}
+
+	private static final class IteratorFromSpliterator KEY_GENERIC implements KEY_ITERATOR KEY_GENERIC, KEY_CONSUMER KEY_GENERIC {
+		private final KEY_SPLITERATOR KEY_EXTENDS_GENERIC spliterator;
+		private KEY_GENERIC_TYPE holder = KEY_NULL;
+		/** Whether we have an element "peeked" from a hasNext that we have yet to return */
+		private boolean hasPeeked = false;
+
+		IteratorFromSpliterator(final KEY_SPLITERATOR KEY_EXTENDS_GENERIC spliterator) {
+			this.spliterator = spliterator;
+		}
+
+		@Override
+		public void accept(final KEY_GENERIC_TYPE item) {
+			holder = item;
+		}
+
+		@Override
+		public boolean hasNext() {
+			if (hasPeeked) return true;
+			boolean hadElement = spliterator.tryAdvance(this);
+			if (!hadElement) return false;
+			hasPeeked = true; 
+			return true;
+		}
+
+		@Override
+		public KEY_GENERIC_TYPE NEXT_KEY() {
+			if (hasPeeked) {
+				hasPeeked = false;
+				return holder;
+			}
+			boolean hadElement = spliterator.tryAdvance(this);
+			if (!hadElement) throw new java.util.NoSuchElementException();
+			return holder;
+		}
+
+		@Override
+		public void forEachRemaining(final METHOD_ARG_KEY_CONSUMER action) {
+			if (hasPeeked) {
+				hasPeeked = false;
+				action.accept(holder);
+			}
+			spliterator.forEachRemaining(action);
+		}
+
+		@Override
+		public int skip(int n) {
+			if (n < 0) throw new IllegalArgumentException("Argument must be nonnegative: " + n);
+			int skipped = 0;
+			if (hasPeeked) {
+				hasPeeked = false;
+				spliterator.skip(1);
+				++skipped;
+				--n;
+			}
+			if (n > 0) {
+				skipped += SafeMath.safeLongToInt(spliterator.skip(n));
+			}
+			return skipped;
+		}
+	}
+
+	/** Wrap a type-specific {@link java.util.Spliterator} as a type-specific {@link java.util.Iterator}
+	 *
+	 * @param spliterator the type-specific {@code Spliterator} to wrap
+	 * @return a type-specific {@code Iterator} that will return the same elements the spliterator will give.
+	 * @see java.util.Spliterators.iterator(java.util.Spliterator)
+	 * @since 8.3.0
+	 */
+	public static KEY_GENERIC KEY_ITERATOR KEY_GENERIC asIterator(final KEY_SPLITERATOR KEY_EXTENDS_GENERIC spliterator) {
+		return new IteratorFromSpliterator KEY_GENERIC_DIAMOND(spliterator);
+	}
 
 #if SMALL_TYPES && (KEY_CLASS_Short || KEY_CLASS_Integer || KEY_CLASS_Long || KEY_CLASS_Float || KEY_CLASS_Double)
 

--- a/drv/Spliterators.drv
+++ b/drv/Spliterators.drv
@@ -253,14 +253,6 @@ public final class SPLITERATORS {
 		}
 
 		@Override
-		public void forEachRemaining(METHOD_ARG_KEY_CONSUMER action) {
-			Objects.requireNonNull(action);
-			while (curr < length) {
-				action.accept(array[offset + curr++]);
-			}
-		}
-
-		@Override
 		public long estimateSize() { return length - curr; }
 		@Override
 		public int characteristics() { return characteristics; }
@@ -282,11 +274,7 @@ public final class SPLITERATORS {
 		}
 
 		@Override
-#if KEYS_PRIMITIVED
 		public void forEachRemaining(final METHOD_ARG_KEY_CONSUMER action) {
-#else // ! KEY_PRIMITIVE == KEY_REFERENCE
-		public void forEachRemaining(final Consumer<? super KEY_GENERIC_CLASS> action) {
-#endif
 			Objects.requireNonNull(action);
 			for (; curr < length; ++curr) {
 				action.accept(array[offset + curr]);
@@ -1502,9 +1490,9 @@ public final class SPLITERATORS {
 	 * unless {@link java.util.Spliterator.CONCURRENT} is to be reported, in which case these two
 	 * are not implicitly reported.
 	 *
-	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
-	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
-	 * expensive. 
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the returned spliterator will
+	 * yeild limited performance gains when run in parallel contexts, as {@link java.util.Spliterator#trySplit()}
+	 * is linear runtime. 
 	 *
 	 * @param iter the type-specific {@code Iterator} to wrap
 	 * @param size the number of elements the iterator will return
@@ -1530,9 +1518,9 @@ public final class SPLITERATORS {
 	 * unless {@link java.util.Spliterator.CONCURRENT} is to be reported, in which case these two
 	 * are not implicitly reported.
 	 *
-	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
-	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
-	 * expensive. 
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the returned spliterator will
+	 * yeild limited performance gains when run in parallel contexts, as {@link java.util.Spliterator#trySplit()}
+	 * is linear runtime.
 	 *
 	 * @param iter the type-specific {@code Iterator} to wrap
 	 * @param size the number of elements the iterator will return
@@ -1551,9 +1539,9 @@ public final class SPLITERATORS {
 	 * <p>The returned spliterator will report{@code additionalCharacterisitcs},
 	 * and for primitive types, {@link Spliterator.NONNULL}.
 	 * 
-	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
-	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
-	 * expensive. 
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the returned spliterator will
+	 * yeild limited performance gains when run in parallel contexts, as {@link java.util.Spliterator#trySplit()}
+	 * is linear runtime.
 	 *
 	 * @param iter the type-specific {@code Iterator} to wrap
 	 * @param characterisitcs the characteristics to report
@@ -1575,9 +1563,9 @@ public final class SPLITERATORS {
 	 * {@link java.util.Spliterator.ORDERED}, {@link java.util.Spliterator.SORTED}, and for primitive types,
 	 * {@link Spliterator.NONNULL}.
 	 *
-	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the parallel performance of
-	 * this spliterator will not be very good; {@link java.util.Spliterator#trySplit()} will be
-	 * expensive. 
+	 * <p>Because {@link java.util.Iterator} is an inherently linear API, the returned spliterator will
+	 * yeild limited performance gains when run in parallel contexts, as {@link java.util.Spliterator#trySplit()}
+	 * is linear runtime.
 	 *
 	 * @param iter the type-specific {@code Iterator} to wrap
 	 * @param additionalCharacterisitcs the characteristics to report

--- a/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
+++ b/test/it/unimi/dsi/fastutil/ints/IntSpliteratorsTest.java
@@ -1,5 +1,6 @@
 package it.unimi.dsi.fastutil.ints;
 
+import java.util.Spliterator;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
@@ -8,6 +9,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 @RunWith(Parameterized.class)
 public class IntSpliteratorsTest {
@@ -21,30 +25,73 @@ public class IntSpliteratorsTest {
 	
 	@Test
 	public void testArraySpliterator() {
-		int[] a = { 2, 3, 4, 10, 5, 42, 10239};
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
 		IntSpliterator m = IntSpliterators.wrap(a);
 		java.util.Spliterator.OfInt t = java.util.Spliterators.spliterator(a, 0);
+		assertEquals(a.length, m.estimateSize());
+		assertEquals(a.length, m.getExactSizeIfKnown());
+		assertEquals(m.estimateSize(), t.estimateSize());
+		assertEquals(Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED | Spliterator.NONNULL, m.characteristics());
 		IntStream mStream = StreamSupport.intStream(m, useSplits);
 		IntStream tStream = StreamSupport.intStream(t, useSplits);
 		int[] mArray = mStream.toArray();
 		int[] tArray = tStream.toArray();
-		org.junit.Assert.assertArrayEquals(mArray, tArray);
+		assertArrayEquals(mArray, tArray);
 	}
 
 	@Test
 	public void testArraySpliteratorSkip() {
-		int[] a = { 2, 3, 4, 10, 5, 42, 10239};
-		int[] expected = { 4, 10, 5, 42, 10239};
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
+		int[] expected = { 4, 10, 5, 42, 10239 };
 		IntSpliterator m = IntSpliterators.wrap(a);
-		org.junit.Assert.assertEquals(2, m.skip(2));
+		assertEquals(a.length, m.getExactSizeIfKnown());
+		assertEquals(2, m.skip(2));
+		assertEquals(expected.length, m.getExactSizeIfKnown());
 		IntStream mStream = StreamSupport.intStream(m, useSplits);
 		int[] mArray = mStream.toArray();
-		org.junit.Assert.assertArrayEquals(expected, mArray);
+		assertArrayEquals(expected, mArray);
+	}
+
+	@Test
+	public void testFromToSpliterator() {
+		final int from = -5;
+		final int to = 17;
+		final int expectedSize = to - from;
+		IntSpliterator m = IntSpliterators.fromTo(from, to);
+		Spliterator.OfInt t = java.util.stream.IntStream.range(from, to).spliterator();
+		assertEquals(expectedSize, m.estimateSize());
+		assertEquals(expectedSize, m.getExactSizeIfKnown());
+		assertEquals(m.estimateSize(), t.estimateSize());
+		assertEquals(Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED
+				| Spliterator.SORTED | Spliterator.DISTINCT | Spliterator.IMMUTABLE
+				| Spliterator.NONNULL, m.characteristics());
+		org.junit.Assert.assertNull(m.getComparator());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		IntStream tStream = java.util.stream.IntStream.range(from, to);
+		if (useSplits) tStream = tStream.parallel();
+		int[] mArray = mStream.toArray();
+		int[] tArray = tStream.toArray();
+		assertArrayEquals(mArray, tArray);
+	}
+
+	@Test
+	public void testFromToSpliteratorSkip() {
+		final int from = -5;
+		final int to = 7;
+		final int expectedSize = to - from;
+		int[] expectedAfterSkipping = { -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 };
+		IntSpliterator m = IntSpliterators.fromTo(from, to);
+		assertEquals(expectedSize, m.getExactSizeIfKnown());
+		assertEquals(2, m.skip(2));
+		assertEquals(expectedSize - 2, m.getExactSizeIfKnown());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		int[] mArray = mStream.toArray();
+		assertArrayEquals(expectedAfterSkipping, mArray);
 	}
 
 	@Test
 	public void testConcatSpliterator() {
-		int[] a = { 2, 4, 6, 8, 10, 12, 14};
+		int[] a = { 2, 4, 6, 8, 10, 12, 14 };
 		int[] b = { 1, 3, 5, 7, 9, 11, 13 };
 		int[] c = { 1, 2, 4, 8, 16 };
 		int[] expectedConcat = { 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 1, 2, 4, 8, 16 };
@@ -52,42 +99,194 @@ public class IntSpliteratorsTest {
 		IntSpliterator bSpliterator = IntSpliterators.wrap(b);
 		IntSpliterator cSpliterator = IntSpliterators.wrap(c);
 		IntSpliterator concatSpliterator = IntSpliterators.concat(aSpliterator, bSpliterator, cSpliterator);
+		assertEquals(expectedConcat.length, concatSpliterator.estimateSize());
+		assertEquals(expectedConcat.length, concatSpliterator.getExactSizeIfKnown());
+		assertEquals(Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED | Spliterator.NONNULL, concatSpliterator.characteristics());
 		IntStream concatStream = StreamSupport.intStream(concatSpliterator, useSplits);
 		int[] actualConcat = concatStream.toArray();
-		org.junit.Assert.assertArrayEquals(expectedConcat, actualConcat);
+		assertArrayEquals(expectedConcat, actualConcat);
 	}
 
 
 	@Test
 	public void testConcatSpliteratorSkipWithinOne() {
-		int[] a = { 2, 4, 6, 8, 10, 12, 14};
+		int[] a = { 2, 4, 6, 8, 10, 12, 14 };
 		int[] b = { 1, 3, 5, 7, 9, 11, 13 };
 		int[] c = { 1, 2, 4, 8, 16 };
+		int[] expectedAfterSkipping = { 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 1, 2, 4, 8, 16 };
 		IntSpliterator aSpliterator = IntSpliterators.wrap(a);
 		IntSpliterator bSpliterator = IntSpliterators.wrap(b);
 		IntSpliterator cSpliterator = IntSpliterators.wrap(c);
 		IntSpliterator concatSpliterator = IntSpliterators.concat(aSpliterator, bSpliterator, cSpliterator);
-		org.junit.Assert.assertEquals(2, concatSpliterator.skip(2));
-		int[] expectedConcat = { 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 1, 2, 4, 8, 16 };
+		assertEquals(expectedAfterSkipping.length + 2, concatSpliterator.getExactSizeIfKnown());
+		assertEquals(2, concatSpliterator.skip(2));
+		assertEquals(expectedAfterSkipping.length, concatSpliterator.getExactSizeIfKnown());
 		IntStream concatStream = StreamSupport.intStream(concatSpliterator, useSplits);
 		int[] actualConcat = concatStream.toArray();
-		org.junit.Assert.assertArrayEquals(expectedConcat, actualConcat);
+		assertArrayEquals(expectedAfterSkipping, actualConcat);
 	}
 
 
 	@Test
 	public void testConcatSpliteratorSkipSpanMultiple() {
-		int[] a = { 2, 4, 6, 8, 10, 12, 14};
+		int[] a = { 2, 4, 6, 8, 10, 12, 14 };
 		int[] b = { 1, 3, 5, 7, 9, 11, 13 };
 		int[] c = { 1, 2, 4, 8, 16 };
+		int[] expectedAfterSkipping = { 5, 7, 9, 11, 13, 1, 2, 4, 8, 16 };
 		IntSpliterator aSpliterator = IntSpliterators.wrap(a);
 		IntSpliterator bSpliterator = IntSpliterators.wrap(b);
 		IntSpliterator cSpliterator = IntSpliterators.wrap(c);
 		IntSpliterator concatSpliterator = IntSpliterators.concat(aSpliterator, bSpliterator, cSpliterator);
-		org.junit.Assert.assertEquals(9, concatSpliterator.skip(9));
-		int[] expectedConcat = { 5, 7, 9, 11, 13, 1, 2, 4, 8, 16 };
+		assertEquals(expectedAfterSkipping.length + 9, concatSpliterator.getExactSizeIfKnown());
+		assertEquals(9, concatSpliterator.skip(9));
+		assertEquals(expectedAfterSkipping.length, concatSpliterator.getExactSizeIfKnown());
 		IntStream concatStream = StreamSupport.intStream(concatSpliterator, useSplits);
 		int[] actualConcat = concatStream.toArray();
-		org.junit.Assert.assertArrayEquals(expectedConcat, actualConcat);
+		assertArrayEquals(expectedAfterSkipping, actualConcat);
+	}
+	
+	@Test
+	public void testAsSpliterator() {
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliterator(IntIterators.wrap(a), a.length, 0);
+		java.util.Spliterator.OfInt t = java.util.Spliterators.spliterator(a, 0);
+		assertEquals(a.length, m.estimateSize());
+		assertEquals(a.length, m.getExactSizeIfKnown());
+		assertEquals(m.estimateSize(), t.estimateSize());
+		assertEquals(Spliterator.SIZED | Spliterator.SUBSIZED, Spliterator.NONNULL, m.characteristics());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		IntStream tStream = StreamSupport.intStream(t, useSplits);
+		int[] mArray = mStream.toArray();
+		int[] tArray = tStream.toArray();
+		assertArrayEquals(mArray, tArray);
+	}
+
+	@Test
+	public void testAsSpliteratorSkip() {
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
+		int[] expected = { 4, 10, 5, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliterator(IntIterators.wrap(a), a.length, 0);
+		assertEquals(a.length, m.getExactSizeIfKnown());
+		assertEquals(2, m.skip(2));
+		assertEquals(expected.length, m.getExactSizeIfKnown());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		int[] mArray = mStream.toArray();
+		assertArrayEquals(expected, mArray);
+	}
+
+	@Test
+	public void testAsSpliteratorUnknownSize() {
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliteratorUnknownSize(IntIterators.wrap(a), 0);
+		java.util.Spliterator.OfInt t = java.util.Spliterators.spliterator(a, 0);
+		assertEquals(Long.MAX_VALUE, m.estimateSize());
+		assertEquals(-1, m.getExactSizeIfKnown());
+		assertEquals(Spliterator.NONNULL, m.characteristics());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		IntStream tStream = StreamSupport.intStream(t, useSplits);
+		int[] mArray = mStream.toArray();
+		int[] tArray = tStream.toArray();
+		assertArrayEquals(mArray, tArray);
+	}
+
+	@Test
+	public void testAsSpliteratorUnknownSizeSkip() {
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
+		int[] expected = { 4, 10, 5, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliteratorUnknownSize(IntIterators.wrap(a), 0);
+		assertEquals(Long.MAX_VALUE, m.estimateSize());
+		assertEquals(-1, m.getExactSizeIfKnown());
+		assertEquals(2, m.skip(2));
+		assertEquals(Long.MAX_VALUE, m.estimateSize());
+		assertEquals(-1, m.getExactSizeIfKnown());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		int[] mArray = mStream.toArray();
+		assertArrayEquals(expected, mArray);
+	}
+
+	@Test
+	public void testAsSortedSpliterator() {
+		int[] a = { 2, 3, 4, 10, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliteratorFromSorted(IntIterators.wrap(a), a.length, 0, IntComparators.NATURAL_COMPARATOR);
+		java.util.Spliterator.OfInt t = java.util.Spliterators.spliterator(a, java.util.Spliterator.ORDERED | java.util.Spliterator.SORTED);
+		assertEquals(a.length, m.estimateSize());
+		assertEquals(a.length, m.getExactSizeIfKnown());
+		assertEquals(m.estimateSize(), t.estimateSize());
+		org.junit.Assert.assertSame(IntComparators.NATURAL_COMPARATOR, m.getComparator());
+		assertEquals(Spliterator.SIZED | Spliterator.SUBSIZED | Spliterator.ORDERED | Spliterator.SORTED | Spliterator.NONNULL, m.characteristics());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		IntStream tStream = StreamSupport.intStream(t, useSplits);
+		int[] mArray = mStream.toArray();
+		int[] tArray = tStream.toArray();
+		assertArrayEquals(mArray, tArray);
+	}
+
+	@Test
+	public void testAsSortedSpliteratorSkip() {
+		int[] a = { 2, 3, 4, 10, 42, 10239 };
+		int[] expected = { 4, 10, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliteratorFromSorted(IntIterators.wrap(a), a.length, 0, IntComparators.NATURAL_COMPARATOR);
+		assertEquals(a.length, m.getExactSizeIfKnown());
+		assertEquals(2, m.skip(2));
+		assertEquals(expected.length, m.getExactSizeIfKnown());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		int[] mArray = mStream.toArray();
+		assertArrayEquals(expected, mArray);
+	}
+
+	@Test
+	public void testAsSortedUnknownSizeSpliterator() {
+		int[] a = { 2, 3, 4, 10, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliteratorFromSortedUnknownSize(IntIterators.wrap(a), 0, IntComparators.NATURAL_COMPARATOR);
+		java.util.Spliterator.OfInt t = java.util.Spliterators.spliterator(a, java.util.Spliterator.ORDERED | java.util.Spliterator.SORTED);
+		assertEquals(Long.MAX_VALUE, m.estimateSize());
+		assertEquals(Long.MAX_VALUE, m.estimateSize());
+		assertEquals(-1, m.getExactSizeIfKnown());
+		org.junit.Assert.assertSame(IntComparators.NATURAL_COMPARATOR, m.getComparator());
+		assertEquals(Spliterator.ORDERED | Spliterator.SORTED | Spliterator.NONNULL, m.characteristics());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		IntStream tStream = StreamSupport.intStream(t, useSplits);
+		int[] mArray = mStream.toArray();
+		int[] tArray = tStream.toArray();
+		assertArrayEquals(mArray, tArray);
+	}
+
+	@Test
+	public void testAsSortedUnknownSizeSpliteratorSkip() {
+		int[] a = { 2, 3, 4, 10, 42, 10239 };
+		int[] expected = { 4, 10, 42, 10239 };
+		IntSpliterator m = IntSpliterators.asSpliteratorFromSortedUnknownSize(IntIterators.wrap(a), 0, IntComparators.NATURAL_COMPARATOR);
+		assertEquals(Long.MAX_VALUE, m.estimateSize());
+		assertEquals(-1, m.getExactSizeIfKnown());
+		assertEquals(2, m.skip(2));
+		assertEquals(Long.MAX_VALUE, m.estimateSize());
+		assertEquals(-1, m.getExactSizeIfKnown());
+		IntStream mStream = StreamSupport.intStream(m, useSplits);
+		int[] mArray = mStream.toArray();
+		assertArrayEquals(expected, mArray);
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testAsIterator() {
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
+		IntIterator m = IntSpliterators.asIterator(IntSpliterators.wrap(a));
+		java.util.PrimitiveIterator.OfInt t = java.util.Spliterators.iterator(java.util.Spliterators.spliterator(a, 0));
+		while (m.hasNext()) {
+			if (!t.hasNext()) org.junit.Assert.fail(" m hasNext() but t does not");
+			assertEquals(m.nextInt(), t.nextInt());
+		}
+		if(t.hasNext()) org.junit.Assert.fail("t hasNext() but m does not");
+	}
+
+	@SuppressWarnings("static-method")
+	@Test
+	public void testAsIteratorSkip() {
+		int[] a = { 2, 3, 4, 10, 5, 42, 10239 };
+		int[] expected = { 4, 10, 5, 42, 10239 };
+		IntIterator m = IntSpliterators.asIterator(IntSpliterators.wrap(a));
+		assertEquals(2, m.skip(2));
+		int[] mArray = IntIterators.unwrap(m);
+		assertArrayEquals(expected, mArray);
 	}
 }


### PR DESCRIPTION
This allows up to have a default implementation of spliterator that does
not rely on widened iterators. This means that the horrible hack of the
ImplementsSpliterator interface is no longer needed, and has been
excised.

The cost for this is yet more classes in Spliterators and no longer
getting potential future performance benefits from the JDK's version of
this method (though that is rather unlikely; there is only so much you
can do wrapping an Iterator)